### PR TITLE
fixing page not found from github and making publish command generic

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,7 +41,13 @@ jobs:
         run: dotnet build -c Release --no-restore
 
       - name: Publish .NET
-        run: dotnet publish BlzDplGhPg.csproj -c:Release -o docs --nologo
+        run: dotnet publish . -c:Release -o docs --nologo
+
+      - name: Copy index.html to 404.html
+        run: cp docs/wwwroot/index.html docs/wwwroot/404.html
+
+      - name: Add .nojekyll file
+        run: touch docs/wwwroot/.nojekyll
 
       - name: Setup Pages
         uses: actions/configure-pages@v4


### PR DESCRIPTION
This will avoid routing problems from github treating the project as a jekyll, and will not use github branded not found page on 404. 

Also the cmd for publish is now generic and doesn't need to be changed for each project.

Used this as reference (https://swimburger.net/blog/dotnet/how-to-deploy-aspnet-blazor-webassembly-to-github-pages)